### PR TITLE
Remove isPseudoLocale options to create resources directory properly

### DIFF
--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -107,8 +107,8 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
         resources = this.extracted.getAll(),
         db = this.project.db,
         translationLocales = locales.filter(function(locale) {
-            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale && !this.API.isPseudoLocale(locale);
-        }.bind(this));;
+            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale;
+        }.bind(this));
 
     for (var i = 0; i < resources.length; i++) {
         res = resources[i];


### PR DESCRIPTION
If put English-Region locales like (en-GB, en-TZ, en-AU etc ) in `project.json` en/  resource directory won't be created. Even though xliff has a different string than source strings.

Because of the following lines,
https://github.com/iLib-js/loctool/blob/development/lib/PseudoFactory.js#L221
https://github.com/iLib-js/loctool/blob/development/lib/PseudoFactory.js#L32

so I removed `!this.API.isPseudoLocale()` statemnt to create resources directory.
We'd better compare source/target string to decide to create resource directories or not.
