### PR TITLE
Update code to get correct result with xliff 2.0 format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -24,7 +24,7 @@ var ResBundle = require("ilib/lib/ResBundle.js");
 var log4js = require("log4js");
 
 var JavaScriptFile = require("./JavaScriptFile.js");
-//var JavaScriptResourceFileType = require("ilib-loctool-webos-json-resource");
+var JavaScriptResourceFileType = require("ilib-loctool-webos-json-resource");
 
 var logger = log4js.getLogger("loctool.plugin.JavaScriptFileType");
 

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -119,7 +119,8 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
 
             db.getResourceByCleanHashKey(res.cleanHashKeyForTranslation(locale), function(err, translated) {
                 var r = translated;
-                if (!translated || this.API.utils.cleanString(res.getSource()) !== this.API.utils.cleanString(r.getSource())) {
+                if (!translated || ( this.API.utils.cleanString(res.getSource()) !== this.API.utils.cleanString(r.getSource()) &&
+                    this.API.utils.cleanString(res.getSource()) !== this.API.utils.cleanString(r.getReskey()))) {
                     if (r) {
                         logger.trace("extracted   source: " + this.API.utils.cleanString(res.getSource()));
                         logger.trace("translation source: " + this.API.utils.cleanString(r.getSource()));

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -120,7 +120,7 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
             db.getResourceByCleanHashKey(res.cleanHashKeyForTranslation(locale), function(err, translated) {
                 var r = translated;
                 if (!translated || ( this.API.utils.cleanString(res.getSource()) !== this.API.utils.cleanString(r.getSource()) &&
-                    this.API.utils.cleanString(res.getSource()) !== this.API.utils.cleanString(r.getReskey()))) {
+                    this.API.utils.cleanString(res.getSource()) !== this.API.utils.cleanString(r.getKey()))) {
                     if (r) {
                         logger.trace("extracted   source: " + this.API.utils.cleanString(res.getSource()));
                         logger.trace("translation source: " + this.API.utils.cleanString(r.getSource()));

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 ilib-webos-loctool-javascript is a plugin for the loctool that
 allows it to read and localize javascript files. This plugins is optimized for webOS platform.
 
+## Release Notes
+v1.0.1
+
+Update to nslation data properly with xliff 2.0 formatreturn translation data with xliff 2.0 format
+
 ## License
 
 Copyright © 2019, JEDLSoft

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     },
     "dependencies": {
         "ilib": "^14.4.0",
+        "ilib-loctool-webos-json-resource": "^1.0.0",
         "log4js": "^5.0.0"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-javascript",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "main": "./JavaScriptFileType.js",
     "description": "A loctool plugin that knows how to process JS files",
     "license": "Apache-2.0",

--- a/test/testfiles/js/t3.js
+++ b/test/testfiles/js/t3.js
@@ -1,0 +1,9 @@
+<SplitItem label={$L('DNS Server')}>{dns || ''}</SplitItem>
+            title: $L('Style'),
+            title: $L('No'),
+<SettingsDivider>{$L({key:'pictureModeSettings', value:'Customize'})}</SettingsDivider>
+        <Container className={css['labeled-picker-item']} role={'region'} aria-label={$L({key:'speaker_channel', value:'Channel'})}>
+            return {
+                'manual': $L('Custom'),
+                'auto': $L({key:'digitalOptionSetByProgram', value:'Set By Program'})
+            };

--- a/test/testfiles/xliff/ko-KR.xliff
+++ b/test/testfiles/xliff/ko-KR.xliff
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-KR" trgLang="ko-KR">
+ <file id="settings_f1" original="settings">
+  <group id="settings_g1" name="javascript">
+   <unit id="settings_1">
+    <segment>
+     <source>DNS Server</source>
+     <target>1.DNS Server</target>
+    </segment>
+   </unit>
+  <unit id="settings_2">
+    <segment>
+     <source>Style</source>
+     <target>2.Style ...</target>
+    </segment>
+   </unit>
+  <unit id="settings_3">
+    <segment>
+     <source>No</source>
+     <target>3. No ...</target>
+    </segment>
+   </unit>
+   <unit id="settings_140" name="pictureModeSettings">
+    <segment>
+     <source>Customize</source>
+     <target>xkey1 상세 설정</target>
+    </segment>
+   </unit>
+   <unit id="settings_192" name="speaker_channel">
+    <segment>
+     <source>Style</source>
+     <target>xkey2 스타일</target>
+    </segment>
+   </unit>
+   <unit id="settings_199">
+    <segment>
+     <source>Custom</source>
+     <target>4. Custom ...</target>
+    </segment>
+   </unit>
+   <unit id="settings_192" name="digitalOptionSetByProgram">
+    <segment>
+     <source>hello hallo</source>
+     <target>xkey3 digitalOption....</target>
+    </segment>
+   </unit>
+  </group>
+ </file>
+</xliff>

--- a/test/testfiles/xliff/sample.xliff
+++ b/test/testfiles/xliff/sample.xliff
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE xliff PUBLIC "-//XLIFF//DTD XLIFF//EN" "http://www.oasis-open.org/committees/xliff/documents/xliff.dtd">
+<xliff version="1.0">
+    <file datatype="javascript" original="settings" source-language="en-KR" target-language="af-ZA">
+        <body>
+        <trans-unit datatype="javascript" id="settings_17095">
+            <source>DNS Server</source>
+                <target>1. DNS-bediener</target>
+        </trans-unit>
+        <trans-unit datatype="javascript" id="settings_16943">
+                <source>Style</source>
+                <target>2. Style...</target>
+        </trans-unit>
+        <trans-unit datatype="javascript" id="settings_16945">
+                <source>No</source>
+                <target>3. No...</target>
+        </trans-unit>
+        <trans-unit datatype="javascript" id="settings_8363">
+                <source x-key="pictureModeSettings">Customize</source>
+                <target>xkey1 Pasmaak</target>
+        </trans-unit>
+        <trans-unit datatype="javascript" id="settings_16564">
+                <source x-key="speaker_channel">Style</source>
+                <target>xkey2 Styl</target>
+        </trans-unit>
+        <trans-unit datatype="javascript" id="settings_17010">
+                <source>Custom</source>
+                <target>4. Custom...</target>
+        </trans-unit>
+        <trans-unit datatype="javascript" id="settings_17011">
+                <source>digitalOptionSetByProgram</source>
+                <target>xkey3 ohohoh</target>
+        </trans-unit>
+
+      </body>
+   </file>
+</xliff>


### PR DESCRIPTION
* Enable necessary JavaScriptResourceFileType require statement 
* Update sample files for testing
* Update code to return translation data

  * source:
`<SettingsDivider>{$L({key:'pictureModeSettings', value:'Customize'})}</SettingsDivider>`
  * xliff 2.0
```
    <unit id="settings_140" name="pictureModeSettings">
     <segment>
      <source>Customize</source>
      <target>xkey1 상세 설정</target>
     </segment>
    </unit>
```
The value in the above case are : 
`res.getSource()) : pictureModeSettings`
`r.getSource(): Customize`
`r.getResKey(): pictureModeSettings`

