### PR TITLE
Make pseudo localization to work properly

### DIFF
--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -23,6 +23,7 @@ var logger = log4js.getLogger("loctool.plugin.JavaScriptFileType");
 var JavaScriptFile = require("./JavaScriptFile.js");
 var JavaScriptResourceFileType = require("ilib-loctool-webos-json-resource");
 
+
 var JavaScriptFileType = function(project) {
     this.type = "javascript";
     this.datatype = "javascript";
@@ -36,6 +37,10 @@ var JavaScriptFileType = function(project) {
     this.pseudo = this.API.newTranslationSet(project.getSourceLocale());
 
     this.pseudos = {};
+
+    if (typeof project.pseudoLocale === "string") {
+        project.pseudoLocale = [project.pseudoLocale];
+    }
 
     // generate all the pseudo bundles we'll need
     project.pseudoLocale && project.pseudoLocale.forEach(function(locale) {

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ allows it to read and localize javascript files. This plugins is optimized for w
 
 ## Release Notes
 v1.2.0
+* Support pseudo localization
 
 v1.1.0
 * Support xliff 2.0 style
    * Update code to return translation data properly with xliff 2.0 format
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ ilib-webos-loctool-javascript is a plugin for the loctool that
 allows it to read and localize javascript files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.2.0
+
 v1.1.0
 * Support xliff 2.0 style
    * Update code to return translation data properly with xliff 2.0 format

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-javascript",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "main": "./JavaScriptFileType.js",
     "description": "A loctool plugin that knows how to process JS files",
     "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -47,12 +47,12 @@
         "node": ">=6.0"
     },
     "dependencies": {
-        "ilib": "^14.5.0",
+        "ilib": "^14.6.0",
         "ilib-loctool-webos-json-resource": "^1.2.0",
         "log4js": "^5.0.0"
     },
     "devDependencies": {
-        "loctool": "^2.6.0",
+        "loctool": "^2.7.0",
         "nodeunit": "^0.11.3"
     }
 }

--- a/test/testJavaScriptFile.js
+++ b/test/testJavaScriptFile.js
@@ -21,6 +21,7 @@ if (!JavaScriptFile) {
     var JavaScriptFile = require("../JavaScriptFile.js");
     var JavaScriptFileType = require("../JavaScriptFileType.js");
     var CustomProject =  require("loctool/lib/CustomProject.js");
+    var RegularPseudo =  require("loctool/lib/RegularPseudo.js");
 }
 
 var p = new CustomProject({
@@ -985,6 +986,105 @@ module.exports.javascriptfile = {
 
         var set = j.getTranslationSet();
         test.equal(set.size(), 10);
+        test.done();
+    },
+    testJavaScriptPseudoLocalization1: function(test) {
+        test.expect(4);
+
+        var j = new JavaScriptFile({
+            project: p,
+            pathName: undefined,
+            type: jsft
+        });
+        test.ok(j);
+
+        j.parse('rb.getStringJS("This is a test")');
+        var set = j.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test");
+        test.ok(r);
+
+        var rb = new RegularPseudo({
+            type: "javascript"
+        });
+        var rs2 = r.generatePseudo("zxx-XX", rb);
+        test.equal(rs2.getTarget(),"Ťĥíš íš à ţëšţ6543210");
+        test.done();
+    },
+    testJavaScriptPseudoLocalization2: function(test) {
+        test.expect(4);
+
+        var j = new JavaScriptFile({
+            project: p,
+            pathName: undefined,
+            type: jsft
+        });
+        test.ok(j);
+
+        j.parse('rb.getStringJS("This is a test")');
+        var set = j.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test");
+        test.ok(r);
+
+        var rb = new RegularPseudo({
+            type: "javascript",
+            locale: "zxx-Hans-XX"
+        });
+        var rs2 = r.generatePseudo("zxx-Hans-XX", rb);
+        test.equal(rs2.getTarget(),"推和意思意思阿推俄思推6543210");
+        test.done();
+    },
+    testJavaScriptPseudoLocalization3: function(test) {
+        test.expect(4);
+
+        var j = new JavaScriptFile({
+            project: p,
+            pathName: undefined,
+            type: jsft
+        });
+        test.ok(j);
+
+        j.parse('rb.getStringJS("This is a test")');
+        var set = j.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test");
+        test.ok(r);
+
+        var rb = new RegularPseudo({
+            type: "javascript",
+            locale: "zxx-Cyrl-XX"
+        });
+        var rs2 = r.generatePseudo("zxx-Cyrl-XX", rb);
+        test.equal(rs2.getTarget(), "Тхис ис а тэст6543210");
+        test.done();
+    },
+    testJavaScriptPseudoLocalization4: function(test) {
+        test.expect(4);
+
+        var j = new JavaScriptFile({
+            project: p,
+            pathName: undefined,
+            type: jsft
+        });
+        test.ok(j);
+
+        j.parse('rb.getStringJS("This is a test")');
+        var set = j.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test");
+        test.ok(r);
+
+        var rb = new RegularPseudo({
+            type: "javascript",
+            locale: "zxx-Hebr-XX"
+        });
+        var rs2 = r.generatePseudo("zxx-Hebr-XX", rb);
+        test.equal(rs2.getTarget(), 'טהִס ִס ַ טֶסט6543210');
         test.done();
     }
 };

--- a/test/testJavaScriptFile.js
+++ b/test/testJavaScriptFile.js
@@ -1031,7 +1031,7 @@ module.exports.javascriptfile = {
 
         var rb = new RegularPseudo({
             type: "javascript",
-            locale: "zxx-Hans-XX"
+            targetLocale: "zxx-Hans-XX"
         });
         var rs2 = r.generatePseudo("zxx-Hans-XX", rb);
         test.equal(rs2.getTarget(),"推和意思意思阿推俄思推6543210");
@@ -1056,7 +1056,7 @@ module.exports.javascriptfile = {
 
         var rb = new RegularPseudo({
             type: "javascript",
-            locale: "zxx-Cyrl-XX"
+            targetLocale: "zxx-Cyrl-XX"
         });
         var rs2 = r.generatePseudo("zxx-Cyrl-XX", rb);
         test.equal(rs2.getTarget(), "Тхис ис а тэст6543210");
@@ -1081,7 +1081,7 @@ module.exports.javascriptfile = {
 
         var rb = new RegularPseudo({
             type: "javascript",
-            locale: "zxx-Hebr-XX"
+            targetLocale: "zxx-Hebr-XX"
         });
         var rs2 = r.generatePseudo("zxx-Hebr-XX", rb);
         test.equal(rs2.getTarget(), 'טהִס ִס ַ טֶסט6543210');


### PR DESCRIPTION
**Description:**
In order to generate pseudo localization resource,
* It needs to run loctool with `-n` or --pseudo` flag
* pseudo locale list could be written to project.json configuration. At least we could write multiple locales as much as  ilib pseudo locale coverage (`zxx-XX, zxx-Hant-XX, zxx-Cyrl-XX, zxx-Hebr-XX`)
```
"pseudoLocale": ["zxx-XX", "zxx-Hant-XX"]
```
**Issues:**
In order to work correctly, the following modification should be together:
https://github.com/iLib-js/loctool/pull/86