### PR TITLE
Support loctool's generate mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ ilib-webos-loctool-javascript is a plugin for the loctool that
 allows it to read and localize javascript files. This plugins is optimized for webOS platform.
 
 ## Release Notes
-v1.2.1
+v1.3.0
 * Updated regular Expression to extract case when resbundle object name is not `rb` or `RB`.
 * Updated code to print log with log4js.
+* Support loctool's geneerate mode.
 
 v1.2.0
 * Support pseudo localization

--- a/package.json
+++ b/package.json
@@ -48,12 +48,12 @@
         "node": ">=6.0"
     },
     "dependencies": {
-        "ilib": "14.6.0",
+        "ilib": "^14.6.0",
         "ilib-loctool-webos-json-resource": "1.2.0",
-        "log4js": "5.0.0"
+        "log4js": "^5.0.0"
     },
     "devDependencies": {
         "loctool": "2.7.2",
-        "nodeunit": "0.11.3"
+        "nodeunit": "^0.11.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-javascript",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "main": "./JavaScriptFileType.js",
     "description": "A loctool plugin that knows how to process JS files",
     "license": "Apache-2.0",
@@ -48,12 +48,12 @@
         "node": ">=6.0"
     },
     "dependencies": {
-        "ilib": "^14.6.0",
-        "ilib-loctool-webos-json-resource": "^1.2.0",
-        "log4js": "^5.0.0"
+        "ilib": "14.6.0",
+        "ilib-loctool-webos-json-resource": "1.2.0",
+        "log4js": "5.0.0"
     },
     "devDependencies": {
-        "loctool": "^2.7.2",
-        "nodeunit": "^0.11.3"
+        "loctool": "2.7.2",
+        "nodeunit": "0.11.3"
     }
 }


### PR DESCRIPTION
Related PR : https://github.com/iLib-js/loctool/pull/119
Depends on the mode(ie.localize, generate), I've updated to work differently.
loctool command example for running `generate` mode

```
node node_modules/loctool/loctool.js generate -x home -2 --projectType webOS --sourceLocale en-KR --resourceFileTypes json=webos-json-resource --plugins webos-javascript,webos-appinfo-json -l ko-KR --projectId home

```

minor:
Update to have a fixed dependent module version. (Not to have caret style versioning)