### PR TITLE
Add script to automatically update copyright year in every js file

### DIFF
--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -17,7 +17,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         path: |
           README.md
-          ./**/*.js
+          test/*.js
         branchName: license/{{currentYear}}
         commitTitle: update license
         commitBody: Let's keep legal happy.

--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -17,7 +17,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         path: |
           README.md
-          test/*.js
+          JavaScriptFile.js
         branchName: license/{{currentYear}}
         commitTitle: update license
         commitBody: Let's keep legal happy.

--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -17,7 +17,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         path: |
           README.md
-		  **/*.js
+		  ./**/*.js
         branchName: license/{{currentYear}}
         commitTitle: update license
         commitBody: Let's keep legal happy.

--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -1,0 +1,25 @@
+name: Update copyright year(s) in license file
+
+on:
+  schedule:
+    - cron: "00 7 22 3 *"
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: master
+        fetch-depth: 0
+    - uses: FantasticFiasco/action-update-license-year@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        path: |
+          README.md
+		  **/*.js
+        branchName: license/{{currentYear}}
+        commitTitle: update license
+        commitBody: Let's keep legal happy.
+        prTitle: Update copyright years in README.md and source files
+        prBody: It's that time of the year, let's update the license.

--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -17,7 +17,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         path: |
           README.md
-          JavaScriptFile.js
+          /**/*.js
         branchName: license/{{currentYear}}
         commitTitle: update license
         commitBody: Let's keep legal happy.

--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -17,7 +17,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         path: |
           README.md
-		  ./**/*.js
+          ./**/*.js
         branchName: license/{{currentYear}}
         commitTitle: update license
         commitBody: Let's keep legal happy.

--- a/JavaScriptFile.js
+++ b/JavaScriptFile.js
@@ -1,7 +1,7 @@
 /*
  * JavaScriptFile.js - plugin to extract resources from a JavaScript source code file
  *
- * Copyright © 2019-2021, JEDLSoft
+ * Copyright (c) 2019-2020, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -1,7 +1,7 @@
 /*
  * JavaScriptFileType.js - Represents a collection of javasript files
  *
- * Copyright © 2019-2021, JEDLSoft
+ * Copyright (c) 2019-2020, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ v1.1.0
 
 ## License
 
-Copyright © 2019-2021, JEDLSoft
+Copyright (c) 2019-2020, JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/assertExtras.js
+++ b/test/assertExtras.js
@@ -1,7 +1,7 @@
 /*
  * assertExtras.js - extra assertion types to use with nodeunit
  *
- * Copyright © 2019-2021, JEDLSoft
+ * Copyright (c) 2019-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/assertExtras.js
+++ b/test/assertExtras.js
@@ -1,7 +1,7 @@
 /*
  * assertExtras.js - extra assertion types to use with nodeunit
  *
- * Copyright (c) 2019-2021, JEDLSoft
+ * Copyright (c) 2019-2020, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testJavaScriptFile.js
+++ b/test/testJavaScriptFile.js
@@ -1,7 +1,7 @@
 /*
  * testJavaScriptFile.js - test the JavaScript file handler object.
  *
- * Copyright © 2019-2021, JEDLSoft
+ * Copyright (c) 2019-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testJavaScriptFile.js
+++ b/test/testJavaScriptFile.js
@@ -1,7 +1,7 @@
 /*
  * testJavaScriptFile.js - test the JavaScript file handler object.
  *
- * Copyright (c) 2019-2021, JEDLSoft
+ * Copyright (c) 2019-2020, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testJavaScriptFileType.js
+++ b/test/testJavaScriptFileType.js
@@ -1,7 +1,7 @@
 /*
  * testJavaScriptFileType.js - test the JavaScript file type handler object.
  *
- * Copyright © 2019-2021, JEDLSoft
+ * Copyright (c) 2019-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testJavaScriptFileType.js
+++ b/test/testJavaScriptFileType.js
@@ -1,7 +1,7 @@
 /*
  * testJavaScriptFileType.js - test the JavaScript file type handler object.
  *
- * Copyright (c) 2019-2021, JEDLSoft
+ * Copyright (c) 2019-2020, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testSuite.js
+++ b/test/testSuite.js
@@ -1,7 +1,7 @@
 /*
  * testSuite.js - test suite for this directory
  * 
- * Copyright (c) 2019-2021, JEDLSoft
+ * Copyright (c) 2019-2020, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testSuite.js
+++ b/test/testSuite.js
@@ -1,7 +1,7 @@
 /*
  * testSuite.js - test suite for this directory
  * 
- * Copyright © 2019-2021, JEDLSoft
+ * Copyright (c) 2019-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testSuiteFiles.js
+++ b/test/testSuiteFiles.js
@@ -1,7 +1,7 @@
 /*
  * testSuiteFiles.js - list the test files in this directory
  * 
- * Copyright © 2019-2021, JEDLSoft
+ * Copyright (c) 2019-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testSuiteFiles.js
+++ b/test/testSuiteFiles.js
@@ -1,7 +1,7 @@
 /*
  * testSuiteFiles.js - list the test files in this directory
  * 
- * Copyright (c) 2019-2021, JEDLSoft
+ * Copyright (c) 2019-20200, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Add script to automatically update copyright year 
- Modified copyright year to see if it's automatically updated in every js file.
- Replace copyright mark to text `(c)` if not, it doesn't work
- schedule to trigger March 22th 07:00 am (UTC)