### PR TITLE
Time is set to update copyright year automatically

### DIFF
--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -2,7 +2,7 @@ name: Update copyright year(s) in license file
 
 on:
   schedule:
-    - cron: "00 8 22 3 *"
+    - cron: "00 1 1 1 *"
 
 jobs:
   run:


### PR DESCRIPTION
I've confirmed that the copyright year of *.js and README.md files are updated correctly with the yml file.
so I've set the schedule to update automatically.
The time is January 1st 1:am (UTC)

I'm going to work the same thing on other plugins to apply this change