### PR TITLE
Fix to handle when a pseudoLocales type is object

### DIFF
--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-var fs = require("fs");
 var path = require("path");
 var log4js = require("log4js");
 var logger = log4js.getLogger("loctool.plugin.JavaScriptFileType");
@@ -37,10 +36,21 @@ var JavaScriptFileType = function(project) {
     this.newres = this.API.newTranslationSet(project.getSourceLocale());
     this.pseudo = this.API.newTranslationSet(project.getSourceLocale());
 
-    this.pseudos = {};
-
+    if (project.pseudoLocale && typeof project.pseudoLocale === "string") {
+        project.pseudoLocale = [project.pseudoLocale];
+    }
     // generate all the pseudo bundles we'll need
-    if (project.pseudoLocales && typeof project.pseudoLocales == 'object'){
+    if (project.pseudoLocale && Array.isArray(project.pseudoLocale)) {
+        this.pseudos = {};
+        project.pseudoLocale && project.pseudoLocale.forEach(function(locale) {
+            var pseudo = this.API.getPseudoBundle(locale, this, project);
+            if (pseudo) {
+                this.pseudos[locale] = pseudo;
+            }
+        }.bind(this));
+    }
+    if (project.pseudoLocales && typeof project.pseudoLocales == 'object') {
+        this.pseudos = {};
         for (locale in project.pseudoLocales) {
             var pseudo = this.API.getPseudoBundle(locale, this, project);
             if (pseudo) {
@@ -48,7 +58,6 @@ var JavaScriptFileType = function(project) {
             }
         }
     }
-
     // for use with missing strings
     if (!project.settings.nopseudo) {
         this.missingPseudo = this.API.getPseudoBundle(project.pseudoLocale, this, project);

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -39,17 +39,15 @@ var JavaScriptFileType = function(project) {
 
     this.pseudos = {};
 
-    if (typeof project.pseudoLocale === "string") {
-        project.pseudoLocale = [project.pseudoLocale];
-    }
-
     // generate all the pseudo bundles we'll need
-    project.pseudoLocale && project.pseudoLocale.forEach(function(locale) {
-        var pseudo = this.API.getPseudoBundle(locale, this, project);
-        if (pseudo) {
-            this.pseudos[locale] = pseudo;
+    if (project.pseudoLocales && typeof project.pseudoLocales == 'object'){
+        for (locale in project.pseudoLocales) {
+            var pseudo = this.API.getPseudoBundle(locale, this, project);
+            if (pseudo) {
+                this.pseudos[locale] = pseudo;
+            }
         }
-    }.bind(this));
+    }
 
     // for use with missing strings
     if (!project.settings.nopseudo) {

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ ilib-webos-loctool-javascript is a plugin for the loctool that
 allows it to read and localize javascript files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.4.4
+* Fix pseudo localization to work properly
+
 v1.4.3
 * Update dependent module version to have the latest one.(loctool: 2.13.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-javascript",
-    "version": "1.4.3",
+    "version": "1.4.4",
     "main": "./JavaScriptFileType.js",
     "description": "A loctool plugin that knows how to process JS files",
     "license": "Apache-2.0",


### PR DESCRIPTION
* In order to work correctly with loctool change: https://github.com/iLib-js/loctool/pull/165
* plugin should handle `project.psseudoLocales` and type is  `object` always. not `array`
