### PR TITLE
Update to clear source and key policy

### DIFF
--- a/JavaScriptFile.js
+++ b/JavaScriptFile.js
@@ -50,8 +50,8 @@ JavaScriptFile.unescapeString = function(string) {
     var unescaped = string;
 
     unescaped = unescaped.
-        replace(/\\\\n/g, "").                // line continuation
-        replace(/\\\n/g, "").                // line continuation
+        /*replace(/\\\\n/g, "").                // line continuation
+        replace(/\\\n/g, "").*/                // line continuation
         replace(/^\\\\/, "\\").             // unescape backslashes
         replace(/([^\\])\\\\/g, "$1\\").
         replace(/^\\'/, "'").               // unescape quotes
@@ -112,7 +112,7 @@ JavaScriptFile.trimComments = function(data) {
  * @returns {String} a unique key for this string
  */
 JavaScriptFile.prototype.makeKey = function(source) {
-    return JavaScriptFile.unescapeString(source);
+    return JavaScriptFile.unescapeString(source).replace(/\s+/gm, ' ');
 };
 
 var reGetStringBogusConcatenation1 = new RegExp(/\.getString(JS)?\s*\(\s*("[^"]*"|'[^']*')\s*\+/g);
@@ -159,9 +159,9 @@ JavaScriptFile.prototype.parse = function(data) {
             var r = this.API.newResource({
                 resType: "string",
                 project: this.project.getProjectId(),
-                key: JavaScriptFile.unescapeString(match),
+                key: this.makeKey(match),
                 sourceLocale: this.project.sourceLocale,
-                source: JavaScriptFile.cleanString(match),
+                source: JavaScriptFile.unescapeString(match),
                 autoKey: true,
                 pathName: this.pathName,
                 state: "new",
@@ -199,9 +199,9 @@ JavaScriptFile.prototype.parse = function(data) {
             var r = this.API.newResource({
                 resType: "string",
                 project: this.project.getProjectId(),
-                key: key,
+                key: this.makeKey(key),
                 sourceLocale: this.project.sourceLocale,
-                source: JavaScriptFile.cleanString(match),
+                source: JavaScriptFile.unescapeString(match),
                 pathName: this.pathName,
                 state: "new",
                 comment: comment,
@@ -237,9 +237,9 @@ JavaScriptFile.prototype.parse = function(data) {
 
             var r = this.API.newResource({
                 project: this.project.getProjectId(),
-                key: JavaScriptFile.unescapeString(match),
+                key: this.makeKey(match),
                 sourceLocale: this.project.sourceLocale,
-                source: JavaScriptFile.cleanString(match),
+                source: JavaScriptFile.unescapeString(match),
                 autoKey: true,
                 pathName: this.pathName,
                 state: "new",
@@ -283,9 +283,9 @@ JavaScriptFile.prototype.parse = function(data) {
 
             var r = this.API.newResource({
                 project: this.project.getProjectId(),
-                key: JavaScriptFile.unescapeString(key),
+                key: this.makeKey(key),
                 sourceLocale: this.project.sourceLocale,
-                source: JavaScriptFile.cleanString(match),
+                source: JavaScriptFile.unescapeString(match),
                 autoKey: true,
                 pathName: this.pathName,
                 state: "new",

--- a/JavaScriptFile.js
+++ b/JavaScriptFile.js
@@ -50,8 +50,6 @@ JavaScriptFile.unescapeString = function(string) {
     var unescaped = string;
 
     unescaped = unescaped.
-        /*replace(/\\\\n/g, "").                // line continuation
-        replace(/\\\n/g, "").*/                // line continuation
         replace(/^\\\\/, "\\").             // unescape backslashes
         replace(/([^\\])\\\\/g, "$1\\").
         replace(/^\\'/, "'").               // unescape quotes

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ allows it to read and localize javascript files. This plugins is optimized for w
 ## Release Notes
 v1.4.7
 * Updated to check language default locale translation not to generate duplicate resources.
+* Updated to make source and key policy clear to avoid confusion.
 
 v1.4.6
 * Updated dependencies. (loctool: 2.16.3)

--- a/test/testJavaScriptFile.js
+++ b/test/testJavaScriptFile.js
@@ -320,15 +320,15 @@ module.exports.javascriptfile = {
         });
         test.ok(j);
 
-        j.parse('RB.getStringJS("\t\t This \\n \n is \\\n\t a    test")');
+        j.parse('RB.getStringJS("\t\t This \n \n is \n\t a    test")');
 
         var set = j.getTranslationSet();
         test.ok(set);
 
-        var r = set.getBySource("This is a test");
+        var r = set.getBySource("\t\t This \n \n is \n\t a    test");
         test.ok(r);
-        test.equal(r.getSource(), "This is a test");
-        test.equal(r.getKey(), "\t\t This \\n \n is \t a    test");
+        test.equal(r.getSource(), "\t\t This \n \n is \n\t a    test");
+        test.equal(r.getKey(), " This is a test");
 
         test.done();
     },


### PR DESCRIPTION
* updated to clear source and key policy to avoid confusion.
     *  original source should not be manipulated except escaping work
     *  key (multi-space to one) which is the same is iLib rule.
* removed unclear unescape rule not sure if it's correct or not.
* updated webos-sample: https://github.com/iLib-js/ilib-loctool-samples/pull/24