### PR TITLE
Updated generate mode to use loctool's new public method

### DIFF
--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -182,7 +182,7 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
         }.bind(this));
     } else {
         // generate mode
-        resources = this.project.db.ts.resources;
+        resources = this.project.getTranslations(translationLocales);
     }
     for (var i = 0; i < resources.length; i++) {
         res = resources[i];

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ ilib-webos-loctool-javascript is a plugin for the loctool that
 allows it to read and localize javascript files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.4.8
+* Updated generate mode to use loctool's new public method.
+
 v1.4.7
 * Updated to check language default locale translation not to generate duplicate resources.
 * Updated to make source and key policy clear to avoid confusion.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-javascript",
-    "version": "1.4.7",
+    "version": "1.4.8",
     "main": "./JavaScriptFileType.js",
     "description": "A loctool plugin that knows how to process JS files",
     "license": "Apache-2.0",
@@ -51,7 +51,7 @@
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "2.17.0",
+        "loctool": "2.18.0",
         "nodeunit": "^0.11.3"
     }
 }


### PR DESCRIPTION
Updated generate mode to use loctool's new public method. this change have a dependency  on loctool 2.18.0'
related loctool's PR: https://github.com/iLib-js/loctool/pull/206