### PR TITLE
Add a feature to use common xliff  data files for localization

### DIFF
--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -22,6 +22,7 @@ var path = require("path");
 var JavaScriptFile = require("./JavaScriptFile.js");
 var JavaScriptResourceFileType = require("ilib-loctool-webos-json-resource");
 var Utils = require("loctool/lib/utils.js")
+var ResourceString = require("loctool/lib/ResourceString.js");
 
 var JavaScriptFileType = function(project) {
     this.type = "javascript";
@@ -165,9 +166,7 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
                     var r = translated;
 
                     if (!translated && this.isloadCommonData) {
-                        var manipulateKey = res.cleanHashKeyForTranslation(locale).
-                                        replace(res.getProject(), this.commonPrjName).
-                                        replace(res.getDataType(), this.commonPrjType);
+                        var manipulateKey = ResourceString.hashKey(this.commonPrjName, locale, res.getKey(), this.commonPrjType, res.getFlavor());
                         db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
                             if (translated) {
                                 translated.project = res.getProject();

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -142,7 +142,6 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
                 this.logger.trace("Localizing JavaScript strings to " + locale);
 
                 baseLocale = Utils.isBaseLocale(locale);
-
                 langDefaultLocale = Utils.getBaseLocale(locale);
                 customInheritLocale = this.project.getLocaleInherit(locale);
 

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -176,7 +176,6 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
                                 file = resFileType.getResourceFile(locale);
                                 file.addResource(translated);
                             } else if(!translated && customInheritLocale){
-                                
                                 db.getResourceByCleanHashKey(res.cleanHashKeyForTranslation(customInheritLocale), function(err, translated) {
                                     if (translated){
                                         translated.setTargetLocale(locale);
@@ -294,12 +293,12 @@ JavaScriptFileType.prototype._loadCommonXliff = function() {
         var data = fs.readFileSync(pathName, "utf-8");
         commonXliff.deserialize(data);
         var resources = commonXliff.getResources();
-        this.ts = this.project.db.ts;
+        var localts = this.project.getRepository().getTranslationSet();
         if (resources.length > 0){
             this.commonPrjName = resources[0].getProject();
             this.commonPrjType = resources[0].getDataType();
             resources.forEach(function(res){
-                this.ts.add(res);
+                localts.add(res);
             }.bind(this));
         }
     }.bind(this));

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -282,13 +282,16 @@ JavaScriptFileType.prototype.getDataType = function() {
 };
 
 JavaScriptFileType.prototype._loadCommonXliff = function() {
-    
     if (fs.existsSync(this.commonPath)){
         var list = fs.readdirSync(this.commonPath);
         console.log(list);
     }
     list.forEach(function(file){
-        var commonXliff = this.API.newXliff(this.project);
+        var commonXliff = this.API.newXliff({
+            sourceLocale: this.project.getSourceLocale(),
+            project: this.project.getProjectId(),
+            path: this.commonPath,
+        });
         var pathName = path.join(this.commonPath, file);
         var data = fs.readFileSync(pathName, "utf-8");
         commonXliff.deserialize(data);

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+var fs = require("fs");
+var path = require("path");
 var JavaScriptFile = require("./JavaScriptFile.js");
 var JavaScriptResourceFileType = require("ilib-loctool-webos-json-resource");
 var Utils = require("loctool/lib/utils.js")
@@ -26,7 +28,7 @@ var JavaScriptFileType = function(project) {
     this.datatype = "javascript";
     this.resourceType = "json";
     this.extensions = [".js", ".jsx"];
-
+    this.isloadCommonData = false;
     this.project = project;
     this.API = project.getAPI();
     this.extracted = this.API.newTranslationSet(project.getSourceLocale());
@@ -58,6 +60,23 @@ var JavaScriptFileType = function(project) {
     // for use with missing strings
     if (!project.settings.nopseudo) {
         this.missingPseudo = this.API.getPseudoBundle(project.pseudoLocale, this, project);
+    }
+
+    if (project.settings.webos["commonXliff"]){
+        this.commonPath = project.settings.webos["commonXliff"];
+        /*if (fs.existsSync(commonPath)){
+            var list = fs.readdirSync(commonPath);
+            console.log(list);
+        }
+        list.forEach(function(file){
+            var xxx = this.API.newXliff(project);
+            var pathName = path.join(commonPath, file);
+            var data = fs.readFileSync(pathName, "utf-8");
+            xxx.deserialize(data);
+            var cts = xxx.getTranslationSet();
+            this.ts.add(cts);
+        }.bind(this));
+        */
     }
 
     if (Object.keys(project.localeMap).length > 0){
@@ -122,6 +141,11 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
             return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale;
         }.bind(this));
 
+    if (this.commonPath && !this.isloadCommonData) {
+        this._loadCommonXliff();
+        this.isloadCommonData = true;
+    }
+
     if (mode === "localize") {
         for (var i = 0; i < resources.length; i++) {
             res = resources[i];
@@ -131,6 +155,7 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
                 this.logger.trace("Localizing JavaScript strings to " + locale);
 
                 baseLocale = Utils.isBaseLocale(locale);
+
                 langDefaultLocale = Utils.getBaseLocale(locale);
                 customInheritLocale = this.project.getLocaleInherit(locale);
 
@@ -230,6 +255,10 @@ JavaScriptFileType.prototype.newFile = function(path) {
 
 JavaScriptFileType.prototype.getDataType = function() {
     return this.datatype;
+};
+
+JavaScriptFileType.prototype._loadCommonXliff = function() {
+    console.log("!!");
 };
 
 JavaScriptFileType.prototype.getResourceTypes = function() {

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -142,7 +142,7 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
         }.bind(this));
 
     if (this.commonPath && !this.isloadCommonData) {
-        this._loadCommonXliff();
+        this._loadCommonXliff(translationLocales);
         this.isloadCommonData = true;
     }
 
@@ -258,7 +258,25 @@ JavaScriptFileType.prototype.getDataType = function() {
 };
 
 JavaScriptFileType.prototype._loadCommonXliff = function() {
-    console.log("!!");
+    
+    if (fs.existsSync(this.commonPath)){
+        var list = fs.readdirSync(this.commonPath);
+        console.log(list);
+    }
+    list.forEach(function(file){
+        var xxx = this.API.newXliff(this.project);
+        var pathName = path.join(this.commonPath, file);
+        var data = fs.readFileSync(pathName, "utf-8");
+        xxx.deserialize(data);
+        var res = xxx.getResources();
+        //this.project.getTranslations(translationLocales);
+        this.ts = this.project.getTranslationSet()
+        for(var i=0;  i< res.length;i++){
+            this.ts.add(res[i]);
+        }
+        console.log("!!!!");
+        //this.ts.add(cts);
+    }.bind(this));
 };
 
 JavaScriptFileType.prototype.getResourceTypes = function() {

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -294,7 +294,6 @@ JavaScriptFileType.prototype._loadCommonXliff = function() {
         var data = fs.readFileSync(pathName, "utf-8");
         commonXliff.deserialize(data);
         var resources = commonXliff.getResources();
-        //this.ts = this.project.getTranslationSet();
         this.ts = this.project.db.ts;
         if (resources.length > 0){
             this.commonPrjName = resources[0].getProject();

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -283,7 +283,6 @@ JavaScriptFileType.prototype.getDataType = function() {
 JavaScriptFileType.prototype._loadCommonXliff = function() {
     if (fs.existsSync(this.commonPath)){
         var list = fs.readdirSync(this.commonPath);
-        console.log(list);
     }
     list.forEach(function(file){
         var commonXliff = this.API.newXliff({

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ allows it to read and localize javascript files. This plugins is optimized for w
 
 ## Release Notes
 v1.6.0
-* Updated dependencies. (loctool: 2.19.0)
+* Updated dependencies. (loctool: 2.20.0)
 * Added ability to define custom locale inheritance.
     ~~~~
        "settings": {

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ v1.6.0
         }
     ~~~~
 * Added ability to use common locale data.
-  * App's xliff data has a higher priority, it there's no matched strings there, then loctool checks data in common directory
+  * App's xliff data has a higher priority, if there's no matched string there, then loctool checks data in the commonXliff directory.
     ~~~~
        "settings": {
             "webos": {

--- a/README.md
+++ b/README.md
@@ -7,10 +7,34 @@ allows it to read and localize javascript files. This plugins is optimized for w
 v1.6.0
 * Updated dependencies. (loctool: 2.19.0)
 * Added ability to define custom locale inheritance.
+    ~~~~
+       "settings": {
+            "localeInherit": {
+                "en-AU": "en-GB"
+            }
+        }
+    ~~~~
+* Added ability to use common locale data.
+  * App's xliff data has a higher priority, it there's no matched strings there, then loctool checks data in common directory
+    ~~~~
+       "settings": {
+            "webos": {
+                "commonXliff": "./common"
+            }
+        }
+    ~~~~
+
 
 v1.5.0
 * Updated dependencies. (loctool: 2.18.0)
 * Added ability to override language default locale.
+    ~~~~
+       "settings": {
+            "localeMap": {
+                "es-CO": "es"
+            }
+        }
+    ~~~~
 * Updated generate mode to use loctool's new public method.
 
 v1.4.7

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "2.19.0",
+        "loctool": "2.20.0",
         "nodeunit": "^0.11.3"
     }
 }


### PR DESCRIPTION
* Added ability to use common locale data.
  * App's xliff data has a higher priority, if  there's no matched string there, then loctool checks data in the common directory
  * related PR: https://github.com/iLib-js/loctool/pull/212
  * sample: https://github.com/iLib-js/ilib-loctool-samples/pull/32