### PR TITLE
 Updated to custom locale inheritance work properly in `generate` mode.

### DIFF
--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -256,6 +256,25 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
     } else {
         // generate mode
         resources = this.project.getTranslations(translationLocales);
+        this.customInherit = translationLocales.filter(function(locale){
+            return this.project.getLocaleInherit(locale) !== undefined;
+        }.bind(this));
+
+        if (this.customInherit.length > 0) {
+            this.customInherit.forEach(function(lo){
+                var res = this.project.getTranslations(lo);
+                if (res.length == 0) {
+                    var inheritlocale = this.project.getLocaleInherit(lo);
+                    var inheritlocaleRes = this.project.getTranslations([inheritlocale]);
+                    inheritlocaleRes.forEach(function(resource){
+                        var newres = resource.clone();
+                        newres.setTargetLocale(lo)
+                        file = resFileType.getResourceFile(lo);
+                        file.addResource(newres);
+                    }.bind(this))
+                }
+            }.bind(this));
+        }
     }
     for (var i = 0; i < resources.length; i++) {
         res = resources[i];

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ ilib-webos-loctool-javascript is a plugin for the loctool that
 allows it to read and localize javascript files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.7.0
+* Updated to custom locale inheritance feature work properly in `generate` mode.
+
 v1.6.0
 * Updated dependencies. (loctool: 2.20.0)
 * Added ability to define custom locale inheritance.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-javascript",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "main": "./JavaScriptFileType.js",
     "description": "A loctool plugin that knows how to process JS files",
     "license": "Apache-2.0",


### PR DESCRIPTION
* Updated to custom locale inheritance feature work properly in `generate` mode.
* sample : https://github.com/iLib-js/ilib-loctool-samples/pull/36