### PR TITLE
Fixed a common  locale inheritance and reskey match issues

### DIFF
--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -105,6 +105,12 @@ JavaScriptFileType.prototype.name = function() {
 
 JavaScriptFileType.prototype._addResource = function(resFileType, translated, res, locale) {
     var file;
+
+    // if reskeys don't match, we matched on cleaned string.
+    // so we need to overwrite reskey of the translated resource to match
+    if (translated.reskey !== res.reskey) {
+        translated.reskey = res.reskey;
+    }
     var resource = translated.clone();
     resource.project = res.getProject();
     resource.datatype = res.getDataType();

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -1,7 +1,7 @@
 /*
  * JavaScriptFileType.js - Represents a collection of javasript files
  *
- * Copyright (c) 2019-2022, JEDLSoft
+ * Copyright (c) 2019-2023, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -179,7 +179,23 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
                                 this._addResource(resFileType, translated, res, locale);
                             } else if(!translated && customInheritLocale){
                                 db.getResourceByCleanHashKey(res.cleanHashKeyForTranslation(customInheritLocale), function(err, translated) {
-                                    if (translated && (baseTranslation !== translated.getTarget())){
+                                    if (!translated) {
+                                        var manipulateKey = ResourceString.hashKey(this.commonPrjName, customInheritLocale, res.getKey(), this.commonPrjType, res.getFlavor());
+                                        db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
+                                            if (translated && (baseTranslation !== translated.getTarget())) {
+                                                this._addResource(resFileType, translated, res, locale);
+                                            } else {
+                                                var newres = res.clone();
+                                                newres.setTargetLocale(locale);
+                                                newres.setTarget((r && r.getTarget()) || res.getSource());
+                                                newres.setState("new");
+                                                newres.setComment(note);
+                                                this.newres.add(newres);
+                                                this.logger.trace("No translation for " + res.reskey + " to " + locale);
+                                            }
+                                        }.bind(this))
+
+                                    } else if (translated && (baseTranslation !== translated.getTarget())){
                                         this._addResource(resFileType, translated, res, locale);
                                     } else {
                                         var newres = res.clone();

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ ilib-webos-loctool-javascript is a plugin for the loctool that
 allows it to read and localize javascript files. This plugins is optimized for webOS platform.
 
 ## Release Notes
-v1.7.1
+v1.8.0
 * Fixed an issue where common's locale inheritance data values were not checked.
+* Updated to match translation's reskey and resource's reskey when they are different.
 
 v1.7.0
 * Updated to custom locale inheritance feature work properly in `generate` mode.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ ilib-webos-loctool-javascript is a plugin for the loctool that
 allows it to read and localize javascript files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.7.1
+* Fixed an issue where common's locale inheritance data values were not checked.
+
 v1.7.0
 * Updated to custom locale inheritance feature work properly in `generate` mode.
 * Added guard code to prevent errors when the common data path is incorrect.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-javascript",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "main": "./JavaScriptFileType.js",
     "description": "A loctool plugin that knows how to process JS files",
     "license": "Apache-2.0",
@@ -51,7 +51,7 @@
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "2.20.0",
+        "loctool": "2.20.2",
         "nodeunit": "^0.11.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-javascript",
-    "version": "1.7.1",
+    "version": "1.8.0",
     "main": "./JavaScriptFileType.js",
     "description": "A loctool plugin that knows how to process JS files",
     "license": "Apache-2.0",

--- a/test/testJavaScriptFile.js
+++ b/test/testJavaScriptFile.js
@@ -1,7 +1,7 @@
 /*
  * testJavaScriptFile.js - test the JavaScript file handler object.
  *
- * Copyright (c) 2019-2022, JEDLSoft
+ * Copyright (c) 2019-2023, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,6 @@ module.exports.javascriptfile = {
         test.ok(j);
         test.done();
     },
-
     testJavaScriptFileConstructorParams: function(test) {
         test.expect(1);
 
@@ -55,7 +54,6 @@ module.exports.javascriptfile = {
         test.ok(j);
         test.done();
     },
-
     testJavaScriptFileConstructorNoFile: function(test) {
         test.expect(1);
 
@@ -67,7 +65,6 @@ module.exports.javascriptfile = {
         test.ok(j);
         test.done();
     },
-
     testJavaScriptFileMakeKey: function(test) {
         test.expect(2);
 
@@ -80,7 +77,6 @@ module.exports.javascriptfile = {
         test.equal(j.makeKey("This is a test"), "This is a test");
         test.done();
     },
-
     testJavaScriptFileParseSimpleGetByKey: function(test) {
         test.expect(5);
 
@@ -106,7 +102,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseSimpleGetBySource: function(test) {
         test.expect(5);
 
@@ -129,7 +124,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseJSSimpleGetBySource: function(test) {
         test.expect(5);
 
@@ -152,7 +146,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseSimpleSingleQuotes: function(test) {
         test.expect(5);
 
@@ -285,7 +278,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseMoreComplexSingleQuotes: function(test) {
         test.expect(5);
 
@@ -308,7 +300,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseSimpleIgnoreWhitespace: function(test) {
         test.expect(5);
 
@@ -331,7 +322,26 @@ module.exports.javascriptfile = {
 
         test.done();
     },
+    testJavaScriptFileParseSimpleIgnoreWhitespace2: function(test) {
+        test.expect(5);
 
+        var j = new JavaScriptFile({
+            project: p,
+            pathName: "./js/t1.js",
+            type: jsft
+        });
+        test.ok(j);
+        j.extract();
+        var set = j.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("Go to  'Settings > General > Channels > Channel Tuning & Settings > Transponder Edit' and add one.");
+        test.ok(r);
+        test.equal(r.getSource(), "Go to  'Settings > General > Channels > Channel Tuning & Settings > Transponder Edit' and add one.");
+        test.equal(r.getKey(), "Go to 'Settings > General > Channels > Channel Tuning & Settings > Transponder Edit' and add one.");
+
+        test.done();
+    },
     testJavaScriptFileParseJSCompressWhitespaceInKey: function(test) {
         test.expect(5);
 
@@ -354,7 +364,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseSimpleRightSize: function(test) {
         test.expect(4);
 
@@ -376,7 +385,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseSimpleWithTranslatorComment: function(test) {
         test.expect(6);
 
@@ -400,7 +408,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseSingleQuotesWithTranslatorComment: function(test) {
         test.expect(6);
 
@@ -424,7 +431,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseSingleQuotesWithEmbeddedSingleQuotes: function(test) {
         test.expect(5);
 
@@ -452,7 +458,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseSingleQuotesWithEmbeddedDoubleQuotes: function(test) {
         test.expect(5);
 
@@ -480,7 +485,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseSimpleWithUniqueIdAndTranslatorComment: function(test) {
         test.expect(6);
 
@@ -506,7 +510,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseWithKey: function(test) {
         test.expect(5);
 
@@ -531,7 +534,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseJSWithKey: function(test) {
         test.expect(5);
 
@@ -556,7 +558,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseWithKeySingleQuotes: function(test) {
         test.expect(5);
 
@@ -581,7 +582,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseJSWithKeySingleQuotes: function(test) {
         test.expect(5);
 
@@ -606,7 +606,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseWithKeyCantGetBySource: function(test) {
         test.expect(3);
 
@@ -627,7 +626,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseMultiple: function(test) {
         test.expect(8);
 
@@ -655,7 +653,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseMultipleWithKey: function(test) {
         test.expect(10);
 
@@ -689,7 +686,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseMultipleSameLine: function(test) {
         test.expect(12);
 
@@ -724,7 +720,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseMultipleWithComments: function(test) {
         test.expect(10);
 
@@ -754,7 +749,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseMultipleWithUniqueIdsAndComments: function(test) {
         test.expect(10);
 
@@ -788,7 +782,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseWithDups: function(test) {
         test.expect(6);
 
@@ -813,7 +806,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseDupsDifferingByKeyOnly: function(test) {
         test.expect(8);
 
@@ -843,7 +835,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseBogusConcatenation: function(test) {
         test.expect(2);
 
@@ -862,7 +853,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseBogusConcatenation2: function(test) {
         test.expect(2);
 
@@ -880,7 +870,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseBogusNonStringParam: function(test) {
         test.expect(2);
 
@@ -898,7 +887,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseEmptyParams: function(test) {
         test.expect(2);
 
@@ -916,7 +904,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseWholeWord: function(test) {
         test.expect(2);
 
@@ -934,7 +921,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseSubobject: function(test) {
         test.expect(2);
 
@@ -952,7 +938,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParsePunctuationBeforeRB: function(test) {
         test.expect(9);
 
@@ -990,7 +975,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileParseEmptyString: function(test) {
         test.expect(3);
 
@@ -1010,7 +994,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileExtractFile: function(test) {
         test.expect(8);
 
@@ -1024,7 +1007,7 @@ module.exports.javascriptfile = {
         // should read the file
         j.extract();
         var set = j.getTranslationSet();
-        test.equal(set.size(), 8);
+        test.equal(set.size(), 9);
 
         var r = set.getBySource("This is a test");
         test.ok(r);
@@ -1040,7 +1023,6 @@ module.exports.javascriptfile = {
 
         test.done();
     },
-
     testJavaScriptFileExtractUndefinedFile: function(test) {
         test.expect(2);
 

--- a/test/testfiles/js/t1.js
+++ b/test/testfiles/js/t1.js
@@ -9,6 +9,7 @@ t1.prototype.tester = function() {
     rb.getString("This is a test1");
     rb.getString("This is a test with a unique id", "id1");
     $L("This is a test with getString Wrapper");
+    $L("Go to  'Settings > General > Channels > Channel Tuning & Settings > Transponder Edit' and add one.")
 };
 createButtonOnPage(webappResBundle.getString("EXIT APP"), "ExitApp_Button", dir_head, onExitApp);
 createButtonOnPage(webappResBundle.getString("RETRY"), "Retry_Button", dir_tail, onRetryApp);


### PR DESCRIPTION
* Fixed an issue where common's locale inheritance data values were not checked.
* Updated to match translation's reskey and resource's reskey when they are different.
* Sampe to check: https://github.com/iLib-js/ilib-loctool-samples/pull/43