### PR TITLE
Fixed not to load common data repeatedly if it's already loaded

### DIFF
--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -145,6 +145,11 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
             return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale;
         }.bind(this));
 
+    if ((typeof(translations) !== 'undefined') && (typeof(translations.getProjects() !== 'undefined') &&
+        translations.getProjects().includes("common"))) {
+        this.isloadCommonData = true;
+    }
+
     if (this.commonPath && !this.isloadCommonData) {
         this._loadCommonXliff();
         this.isloadCommonData = true;

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -145,8 +145,7 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
             return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale;
         }.bind(this));
 
-    if ((typeof(translations) !== 'undefined') && (typeof(translations.getProjects() !== 'undefined') &&
-        translations.getProjects().includes("common"))) {
+    if ((typeof(translations) !== 'undefined') && (typeof(translations.getProjects()) !== 'undefined') && (translations.getProjects().includes("common"))) {
         this.isloadCommonData = true;
     }
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ allows it to read and localize javascript files. This plugins is optimized for w
 
 ## Release Notes
 v1.8.3
-* Fixed not to repeately load common data if it's loaded from another plugin in a project.
+* Fixed not to load common data repeatedly if it's loaded from another plugin in a project.
 
 v1.8.2
 * Updated dependencies.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ ilib-webos-loctool-javascript is a plugin for the loctool that
 allows it to read and localize javascript files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.8.3
+* Fixed not to repeately load common data if it's loaded from another plugin in a project.
+
 v1.8.2
 * Updated dependencies.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-javascript",
-    "version": "1.8.2",
+    "version": "1.8.3",
     "main": "./JavaScriptFileType.js",
     "description": "A loctool plugin that knows how to process JS files",
     "license": "Apache-2.0",
@@ -51,7 +51,7 @@
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "2.20.2",
+        "loctool": "2.20.3",
         "nodeunit": "^0.11.3"
     }
 }


### PR DESCRIPTION
* Fixed not to load common data repeatedly if it's loaded from another plugin in a project.
  * Same change need to be applied to other webos plugin as well.