### PR TITLE
 Updated not to load common data repeatedly if it's loaded from another plugin in a project

### DIFF
--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -153,7 +153,7 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
             this._loadCommonXliff();
             this.isloadCommonData = true;
         }
-        this._addCommonData(translations);
+        this._addCommonDataTranslationSet(translations);
     }
 
     if (mode === "localize") {
@@ -369,9 +369,9 @@ JavaScriptFileType.prototype.getDataType = function() {
     return this.datatype;
 };
 
-JavaScriptFileType.prototype._addCommonData = function(tsdata) {
+JavaScriptFileType.prototype._addCommonDataTranslationSet = function(tsdata) {
     var prots = this.project.getRepository().getTranslationSet();
-    var commonts = tsdata.getBy({project:"common"});
+    var commonts = tsdata.getBy({project: "common"});
     if (commonts.length > 0){
         this.commonPrjName = commonts[0].getProject();
         this.commonPrjType = commonts[0].getDataType();

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -153,7 +153,7 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
             this._loadCommonXliff();
             this.isloadCommonData = true;
         } else {
-            this._manipulateCommondata(translations);
+            this._addComonDatatoTranslationSet(translations);
         }
     }
 
@@ -370,7 +370,7 @@ JavaScriptFileType.prototype.getDataType = function() {
     return this.datatype;
 };
 
-JavaScriptFileType.prototype._manipulateCommondata = function(tsdata) {
+JavaScriptFileType.prototype._addComonDatatoTranslationSet = function(tsdata) {
     var prots = this.project.getRepository().getTranslationSet();
     var commonts = tsdata.getBy({project: "common"});
     if (commonts.length > 0){

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -152,8 +152,9 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
         if (!this.isloadCommonData) {
             this._loadCommonXliff();
             this.isloadCommonData = true;
+        } else {
+            this._manipulateCommondata(translations);
         }
-        this._addCommonDataTranslationSet(translations);
     }
 
     if (mode === "localize") {
@@ -369,7 +370,7 @@ JavaScriptFileType.prototype.getDataType = function() {
     return this.datatype;
 };
 
-JavaScriptFileType.prototype._addCommonDataTranslationSet = function(tsdata) {
+JavaScriptFileType.prototype._manipulateCommondata = function(tsdata) {
     var prots = this.project.getRepository().getTranslationSet();
     var commonts = tsdata.getBy({project: "common"});
     if (commonts.length > 0){

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -145,9 +145,15 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
             return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale;
         }.bind(this));
 
-    if (this.commonPath && !this.isloadCommonData) {
-        this._loadCommonXliff();
+    if ((typeof(translations) !== 'undefined') && (typeof(translations.getProjects()) !== 'undefined') && (translations.getProjects().includes("common"))) {
         this.isloadCommonData = true;
+    }
+    if (this.commonPath) {
+        if (!this.isloadCommonData) {
+            this._loadCommonXliff();
+            this.isloadCommonData = true;
+        }
+        this._addCommonData(translations);
     }
 
     if (mode === "localize") {
@@ -362,6 +368,18 @@ JavaScriptFileType.prototype.newFile = function(path) {
 JavaScriptFileType.prototype.getDataType = function() {
     return this.datatype;
 };
+
+JavaScriptFileType.prototype._addCommonData = function(tsdata) {
+    var prots = this.project.getRepository().getTranslationSet();
+    var commonts = tsdata.getBy({project:"common"});
+    if (commonts.length > 0){
+        this.commonPrjName = commonts[0].getProject();
+        this.commonPrjType = commonts[0].getDataType();
+        commonts.forEach(function(ts){
+            prots.add(ts);
+        }.bind(this));
+    }
+}
 
 JavaScriptFileType.prototype._loadCommonXliff = function() {
     if (fs.existsSync(this.commonPath)){

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -145,7 +145,7 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
             return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale;
         }.bind(this));
 
-    if ((typeof(translations) !== 'undefined') && (typeof(translations.getProjects()) !== 'undefined') && (translations.getProjects().includes("common"))) {
+    if ((typeof(translations) !== 'undefined') && (typeof(translations.getProjects()) !== 'undefined') && (translations.getProjects().indexOf("common") !== -1)) {
         this.isloadCommonData = true;
     }
     if (this.commonPath) {

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ ilib-webos-loctool-javascript is a plugin for the loctool that
 allows it to read and localize javascript files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.9.0
+* Updated not to load common data repeatedly if it's loaded from another plugin in a project.
+
 v1.8.2
 * Updated dependencies.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-javascript",
-    "version": "1.8.2",
+    "version": "1.9.0",
     "main": "./JavaScriptFileType.js",
     "description": "A loctool plugin that knows how to process JS files",
     "license": "Apache-2.0",


### PR DESCRIPTION
* Updated not to load common data repeatedly if it's loaded from another plugin in a project.
  * Implemented not to load/read common data files if it's already loaded. only add data to the translation set.